### PR TITLE
Fix type error with single meta scheme

### DIFF
--- a/bin/schema-validator
+++ b/bin/schema-validator
@@ -47,7 +47,7 @@ rx = Rx.new({ :load_core => true })
 unless meta_schemata.empty?
   puts "Learning meta schemata"
 end
-# ensure meta_schemata is an array
+
 meta_schemata = [meta_schemata] unless meta_schemata.kind_of?(Array)
 meta_schemata.each do |meta_schema|
   begin

--- a/bin/schema-validator
+++ b/bin/schema-validator
@@ -47,6 +47,8 @@ rx = Rx.new({ :load_core => true })
 unless meta_schemata.empty?
   puts "Learning meta schemata"
 end
+# ensure meta_schemata is an array
+meta_schemata = [meta_schemata] unless meta_schemata.kind_of?(Array)
 meta_schemata.each do |meta_schema|
   begin
     rx.learn_type(meta_schema['uri'], meta_schema['schema'])


### PR DESCRIPTION
When I tried to load a metaschema file with only a single metaschema, schema-validator crashed with a type error. This happened because the meta_schemata variable below was not an array. 

I added a line that makes meta_schemata an array if it is not already.